### PR TITLE
Mac OSX instructions didn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I (Kyle Burton) have a custom [brew tap](https://github.com/kyleburton/homebrew-
 brew tap --full github/kyleburton https://github.com/kyleburton/homebrew-kyleburton.git
 
 # recommended on OS X (bake depends on of bash supporting arrays)
-brew install github/kyleburton/bake
+brew install kyleburton/kyleburton/bake
 
 # recommended on Linux (Linux already has a good bash)
 brew install github/kyleburton/bake --without-bash


### PR DESCRIPTION
It's mapping to "https://github.com/github/homebrew-kyleburton"

> $  brew install github/kyleburton/bake
> ==> Tapping github/kyleburton
> Cloning into '/usr/local/Homebrew/Library/Taps/github/homebrew-kyleburton'...
> remote: Repository not found.
> fatal: repository 'https://github.com/github/homebrew-kyleburton/' not found
> Error: Failure while executing: git clone https://github.com/github/homebrew-kyleburton /usr/local/Homebrew/Library/Taps/github/homebrew-kyleburton --depth=1
> 

> $  brew install kyleburton/kyleburton/bake
> ==> Tapping kyleburton/kyleburton
> Cloning into '/usr/local/Homebrew/Library/Taps/kyleburton/homebrew-kyleburton'...
> remote: Counting objects: 6, done.
> remote: Compressing objects: 100% (6/6), done.
> remote: Total 6 (delta 0), reused 3 (delta 0), pack-reused 0
> Unpacking objects: 100% (6/6), done.
> Checking connectivity... done.
> Tapped 2 formulae (30 files, 23.6KB)
> ==> Installing bake from kyleburton/kyleburton