### PR TITLE
Fixed up Bake to always use relative bake path.

### DIFF
--- a/bake
+++ b/bake
@@ -34,7 +34,7 @@ BAKE_LOG_LEVEL="${BAKE_LOG_LEVEL:-$BAKE_LOG_LEVEL_INFO}"
 #
 #  The list of directories that bake will search when resolving libraries (via require)
 #
-BAKEPATH="${BAKEPATH:-.}"
+BAKEPATH=${BAKEPATH:+$BAKEPATH:}$PWD
 
 BAKE_PACKAGES_PATH="$HOME/.bake/packages"
 

--- a/test/Bakefile
+++ b/test/Bakefile
@@ -121,6 +121,20 @@ function 08_catch_failed_require () {
   bake_echo_green "This is after the require, if you see this then the test failed."
 }
 
+bake_test 09_test_bakepath
+function 09_test_bakepath () {
+  bake_echo_green "This tests that setting a Bakepath works appropriately"
+  BAKEPATH="$PWD/lib" ../bake 09_test_bakepath_helper
+  bake_echo_green "This is after the require, if you see this then the test succeeded."
+}
+
+bake_task 09_test_bakepath_helper "Called by the associated test"
+function 09_test_bakepath_helper () {
+  bake_echo_green "This should be called with the BAKEPATH=\"$PWD\"/lib by the associated test"
+  bake_require lib/mylib.sh
+  bake_require mylib.sh
+}
+
 bake_task all
 function all () {
   bake_log_level fatal


### PR DESCRIPTION
By default, if you have a BAKEPATH set, bake ignores the relative local path. This makes me sad. I want to be able to set a BAKEPATH but also have bake work as intended by always leveraging its current location for further requires.