### PR TITLE
Complete only the first arg to bake

### DIFF
--- a/bake-completion.sh
+++ b/bake-completion.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 
 _bake () {
-  local cur
-  _get_comp_words_by_ref -n : -c cur
-  local tasks="$(bake | grep -v BAKEFILE | grep '^  ' | sed 's/^  //g' | cut -f1 -d' ')"
-  COMPREPLY=( $(compgen -W "$tasks" -- $cur) )
+  local cword cur tasks
+  _get_comp_words_by_ref -n : -c cur cword
+  tasks="$(bake | grep -v BAKEFILE | grep '^  ' | sed 's/^  //g' | cut -f1 -d' ')"
+  if [[ "$cword" -eq "1" ]]; then
+    mapfile -t COMPREPLY < <(compgen -W "$tasks" -- "$cur")
+  else
+    mapfile -t COMPREPLY < <(compgen -o default -- "$cur")
+  fi
 
   # NB: this is a workaround for bash's default of splitting words on colons
   # when bake tasks also use colons as a namespace separator.  What we need to


### PR DESCRIPTION
The current implementation for bake completion attempts to complete all arguments to `bake` with bake tasks. In practice, bake tasks are always one word and therefore attempting to complete every arg to `bake` with the name of a bake task is unnecessary.
take for example the following Bakefile
```bash
#!/usr/bin/env bash

bake_task run "Run the project"
function run () {
  # do some stuff
  return 0
}

bake_task run.tests
function run.tests () {
  my_test_runner "$@"
}
```
When completing calls to the bake I get something like:
```bash
> bake run
run        run.tests
```
However if I try completing beyond `run.tests` I get
```bash
> bake run.tests run
run        run.tests
```
With my proposed changes this completion would become
```bash
> bake run.tests
Bakefile  tests

# or if I keep going
> bake run.tests tests/script
tests/script1.bash  tests/script2.bash
```

In the end, default completion still isn't perfect for all scenarios, but I believe it is a sane stopgap baring any extensive support for bake task-level completions!