### PR TITLE
Fix git import for packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,40 @@ Pushes a file system path onto the end of `BAKEPATH`.
 
 ### `bake_require libname`
 
-Searches `BAKEPATH` for the library and sources it, loading the file (executing its contents).  Libraries should (generally) only contain declarations, as any imperative code will be executed when the library is loaded.  Libraries may load other libraries.
+Searches `BAKEPATH` for the library and sources it, loading the file (executing its contents).  Libraries should (generally) only contain declarations, as any imperative code will be executed when the library is loaded.  Libraries may load other libraries. 
+
+You can also load libraries from Github or Enterprise Github instances.  See the [Remote Libraries](#remote_libraries) section for more details.
 
 ## Look Ma, no `Bakefile` aka lets use a `./bake` directory
 
 `bake` can also be used without a `Bakefile`, if you make a directory called `bake` and place shell files within it, `bake` will treat everything in that directory as library and require it automatically.  See the section on libraries below.
 
-# Libraries!
+
+# Libraries
 
 Some of the goals I had for for `bake` are for it to encourage best practices for shell scripting and to encourage re-use by encouraging the creation of small re-useable parts including libraries.  Bake encourages small re-useable functions essentially by requiring the use of shell functions.  It's up to you to break your functions into libraries that can be shared across your projects.  Have a look at the [Best Practices](#best-practices) section below.
+
+## Remote Libraries
+
+Loading via Github via http/https
+```
+bake_require github.com/john/bakelib/my_bake_funcs
+bake_require https://github.com/john/bakelib/my_bake_funcs
+```
+
+Or via ssh
+```
+bake_require ssh://github.acme.com/john/bakelib/my_bake_funcs
+bake_require git@github.acme.com:john/bakelib.git/my_bake_funcs
+```
+
+You can also load from branches or tags
+```
+bake_require ssh://github.acme.com/john/bakelibs/my_bake_funcs develop
+bake_require github.com/steve/examples/lib1 1.0.2
+```
+
+If you want to update your locally installed version of the libraries, you can run `bake update`
 
 ### `BAKEPATH`
 

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ bake make-release
 
 * Kyle Burton &lt;kyle.burton@gmail.com&gt;
 * Isaac Schaaf &lt;zeekus99@gmail.com&gt;
+* Steve Hajducko &lt;hajducko@gmail.com&gt;
 
 # License
 

--- a/bake
+++ b/bake
@@ -158,7 +158,10 @@ function bake_url_to_package_path () {
   local fpath
   fpath=${url##*://}
   fpath=${fpath##git@}
-  fpath=${fpath%%.git}
+
+  # Nuke the .git/ if left in path
+  fpath=${fpath/.git\///}
+
   echo "$BAKE_PACKAGES_PATH/$fpath"
 }
 
@@ -168,9 +171,21 @@ function bake_git_to_url () {
   local path
 
   [[ $url =~ git@(.*):(.*) ]] && host=${BASH_REMATCH[1]} && path=${BASH_REMATCH[2]}
-  echo ssh://git@${host}/${path}
+  echo ssh://git@"${host}"/"${path}"
 }
 
+function bake_sanitize_url () {
+  local url="$1"
+
+  # If no schema, assume it's https
+  if [[ $url != *://* ]]; then
+    url=https://${url}
+  fi
+
+  # Remove any .git in the url
+  url=${url/.git\///}
+  echo "$url"
+}
 
 function bake_ensure_bake_packages_path () {
   test -d "$BAKE_PACKAGES_PATH" || mkdir -p "$BAKE_PACKAGES_PATH"
@@ -179,41 +194,42 @@ function bake_ensure_bake_packages_path () {
 function bake_package_install () {
   local url="$1"
   local tag="${2:-master}"
-  local schema=
+  local schema=${url%%://*}
 
-  trap "bake_echo_red 'Error[bake_package_install] git command not found in PATH'" EXIT
-    which git > /dev/null
-  trap EXIT # clear the trap
-
-  # If no schema, assume it's https
-  if [[ $url != *://* ]]; then
-    url=https://${url}
+  if ! command -v git > /dev/null; then
+   bake_echo_red "Error[bake_package_install] git command not found in PATH" EXIT
+   exit 1
   fi
-  schema=${url%%://*}
 
   bake_ensure_bake_packages_path
   pushd "$BAKE_PACKAGES_PATH" > /dev/null
 
   local git_project_name=
   local git_host_and_user=
-  echo URL is $url
+  local bake_library_file=
+
   [[ $url =~ [a-zA-Z]+://([a-zA-Z0-9@-_.]+/[a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/(.*) ]] && \
     git_host_and_user=${BASH_REMATCH[1]} && \
-    git_project_name=${BASH_REMATCH[2]}
+    git_project_name=${BASH_REMATCH[2]} && \
+    bake_library_file=${BASH_REMATCH[3]}
 
-  trap "bake_echo_red 'Error[bake_package_install] could not parse url $url'" EXIT
-    test -n "$git_host_and_user"
-    test -n "$git_project_name"
-  trap EXIT
+  if [[ -z "$git_host_and_user" ]] || [[ -z "$git_project_name" ]]; then
+    bake_echo_red "Error[bake_package_install] Could not parse url '$url'"
+    exit 1
+  fi
+
+  if [[ -z "$bake_library_file" ]]; then
+    bake_echo_red "Error[bake_package_install] No library file specified"
+    exit 1
+  fi
 
   local git_url
   git_url=${git_host_and_user}/${git_project_name}
   git_host_and_user=${git_host_and_user##git@}
-  git_project_name=${git_project_name%%.git}
   test -d "$git_host_and_user" || mkdir -p "$git_host_and_user"
   cd "$git_host_and_user"
 
-  if [ ! -e "$git_project_name" ]; then
+  if [[ ! -e "$git_project_name" ]]; then
     git clone "$schema://$git_url"
   fi
 
@@ -232,7 +248,6 @@ function bake_require_from_url () {
 
   if [ -e "$fspath" ]; then
     # shellcheck disable=SC2064
-    echo $fspath exists
     trap "bake_echo_red 'Error[bake_require_from_url] loading require: $fspath'" EXIT
     source "$fspath"
     trap EXIT # clear the trap
@@ -257,9 +272,11 @@ function bake_require_from_url () {
 function bake_require () {
   local module="$1"
   if bake_looks_like_url "$module"; then
+    module="$(bake_sanitize_url "$module")"
     bake_require_from_url "$module"
   elif bake_looks_like_git "$module"; then
     module="$(bake_git_to_url "$module")"
+    module="$(bake_sanitize_url "$module")"
     bake_require_from_url "$module"
   else
     bake_require_from_fs "$module"

--- a/bake
+++ b/bake
@@ -4,7 +4,7 @@ set -Eeu -o pipefail
 
 
 # TODO: detect if we're being sourced or if we're being executed
-BAKE_VERSION="2014-11-05"
+BAKE_VERSION="1.0.15"
 BAKE_STDOUT_IS_TERMINAL=""
 BAKE_COLOR_NORMAL=""
 BAKE_COLOR_RED=""
@@ -77,6 +77,15 @@ function bake_bakefile_dir () {
 
 BAKE_ROOT_DIR="$(bake_root_dir)"
 
+function bake_looks_like_git () {
+  local thing="$1"
+
+  if [[ $thing == git@* ]]; then
+    return 0
+  fi
+  return 1
+}
+
 function bake_looks_like_url () {
   local thing="$1"
 
@@ -89,6 +98,10 @@ function bake_looks_like_url () {
   fi
 
   if [[ $thing == github.com/* ]]; then
+    return 0
+  fi
+
+  if [[ $thing == ssh://* ]]; then
     return 0
   fi
 
@@ -140,47 +153,24 @@ function bake_require_from_fs () {
 
 function bake_url_to_package_path () {
   local url="$1"
-  # strip the http:// or https:// if present
+  # strip the *:// if present
   # then see if it exists as $BAKE_PACKAGES_PATH/$url
   local fpath
-  fpath="$(echo "$url" | sed 's/^https\?:\/\///')"
+  fpath=${url##*://}
+  fpath=${fpath##git@}
+  fpath=${fpath%%.git}
   echo "$BAKE_PACKAGES_PATH/$fpath"
 }
 
-function bake_require_git () {
+function bake_git_to_url () {
   local url="$1"
-  local libpath="$2"
-  local tag="${3:-master}"
+  local host
+  local path
 
-  bake_ensure_bake_packages_path
-
-  pushd "$BAKE_PACKAGES_PATH" >/dev/null
-
-  # git@github.com:kyleburton/bake-recipes.git
-  # https://github.com/kyleburton/bake-recipes.git
-  # strip the leading git@, http:// or https://
-  local full_package_path
-  full_package_path="$(echo "$url" | sed 's/^git@//' | sed 's/https:\/\///' | sed 's/http:\/\///' | sed 's/.git$//' | sed 's/:/\//')"
-  local package_path
-  package_path="$(dirname "$full_package_path")"
-
-  test -d "$package_path" || mkdir -p "$package_path"
-  cd "$package_path"
-  local dname
-  dname="$(basename "$full_package_path")"
-  if [ ! -d "$dname" ]; then
-    git clone "$url"
-    cd "$dname"
-    git fetch
-    git co "$tag"
-  fi
-
-  popd > /dev/null
-
-  # translate the require path to local fs path
-  # source it!
-  source "$BAKE_PACKAGES_PATH/$full_package_path/$libpath"
+  [[ $url =~ git@(.*):(.*) ]] && host=${BASH_REMATCH[1]} && path=${BASH_REMATCH[2]}
+  echo ssh://git@${host}/${path}
 }
+
 
 function bake_ensure_bake_packages_path () {
   test -d "$BAKE_PACKAGES_PATH" || mkdir -p "$BAKE_PACKAGES_PATH"
@@ -189,20 +179,45 @@ function bake_ensure_bake_packages_path () {
 function bake_package_install () {
   local url="$1"
   local tag="${2:-master}"
+  local schema=
+
+  trap "bake_echo_red 'Error[bake_package_install] git command not found in PATH'" EXIT
+    which git > /dev/null
+  trap EXIT # clear the trap
+
+  # If no schema, assume it's https
+  if [[ $url != *://* ]]; then
+    url=https://${url}
+  fi
+  schema=${url%%://*}
 
   bake_ensure_bake_packages_path
-  pushd "$BAKE_PACKAGES_PATH"
-  local git_project_name
-  git_project_name="$(echo "$url" | awk -F/ '{print $3 }')"
-  local git_host_and_user
-  git_host_and_user="$(echo "$url" | awk -F/ '{print $1 "/" $2 }')"
+  pushd "$BAKE_PACKAGES_PATH" > /dev/null
+
+  local git_project_name=
+  local git_host_and_user=
+  echo URL is $url
+  [[ $url =~ [a-zA-Z]+://([a-zA-Z0-9@-_.]+/[a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/(.*) ]] && \
+    git_host_and_user=${BASH_REMATCH[1]} && \
+    git_project_name=${BASH_REMATCH[2]}
+
+  trap "bake_echo_red 'Error[bake_package_install] could not parse url $url'" EXIT
+    test -n "$git_host_and_user"
+    test -n "$git_project_name"
+  trap EXIT
+
   local git_url
-  git_url="$(echo "$url" | awk -F/ '{print $1 "/" $2 "/" $3}')"
+  git_url=${git_host_and_user}/${git_project_name}
+  git_host_and_user=${git_host_and_user##git@}
+  git_project_name=${git_project_name%%.git}
   test -d "$git_host_and_user" || mkdir -p "$git_host_and_user"
   cd "$git_host_and_user"
+
   if [ ! -e "$git_project_name" ]; then
-    git clone "https://$git_url"
+    git clone "$schema://$git_url"
   fi
+
+  # Checkout the project and branch/tag
   cd "$git_project_name"
   git checkout .
   git pull
@@ -217,6 +232,7 @@ function bake_require_from_url () {
 
   if [ -e "$fspath" ]; then
     # shellcheck disable=SC2064
+    echo $fspath exists
     trap "bake_echo_red 'Error[bake_require_from_url] loading require: $fspath'" EXIT
     source "$fspath"
     trap EXIT # clear the trap
@@ -241,6 +257,9 @@ function bake_require_from_url () {
 function bake_require () {
   local module="$1"
   if bake_looks_like_url "$module"; then
+    bake_require_from_url "$module"
+  elif bake_looks_like_git "$module"; then
+    module="$(bake_git_to_url "$module")"
     bake_require_from_url "$module"
   else
     bake_require_from_fs "$module"


### PR DESCRIPTION
This fixes importing for packages coming from git.  It adds support for importing over ssh and gets rid of dependencies on sed ( because OSX's sed is trash ) and awk.

The only thing not supported is packages that want to use the Git daemon protocol, but it's recommended that you wrap that in ssh/https anyways, due to it's concerning lack of auth.