### PR TITLE
Fix bake init bug, update getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,20 +44,24 @@ Organizing code into libraries is recommended, so we're going to start off with 
 
 
 ```sh
-$ test -d test/lib || mkdir test/lib
-$ cat > test/lib/mylib.sh
+# Create a test folder to hold the bake libraries
+test -d test/lib || mkdir -p test/lib
+
+# Create library with a bake task
+cat > 'test/lib/mylib.sh' <<'EOF'
 #!/usr/bin/env bash
 bake_task mylib:foo "The foo command just echo's its arguments"
 function mylib:foo () {
   echo "foo: args='$@'"
 }
-^D
+EOF
 
-$ cat > Bakefile
+# Create Bakefile to include libraries
+cat > 'Bakefile' <<'EOF'
 #!/usr/bin/env bash
 bake_push_libdir $(bake_bakefile_dir)/test/lib
 bake_require mylib
-^D
+EOF
 ```
 
 Then run bake:
@@ -70,7 +74,7 @@ bake task [arg ...]
   mylib:foo                      The foo command just echo's its arguments
 
 
-$ bake foo this that
+$ bake mylib:foo this that
 foo: args='this that'
 ```
 

--- a/bake
+++ b/bake
@@ -440,19 +440,19 @@ function bake_inernal_help () {
 function bake_sorted_task_list () {
   (
    for task in "${!BAKE_TASKS[@]}"; do
-     if ! bake_is_registered_subtask $task; then
-       echo $task
+     if ! bake_is_registered_subtask "$task"; then
+       echo "$task"
      fi
    done;
    for task in "${!BAKE_SUPERTASKS[@]}"; do
-     echo $task
+     echo "$task"
    done
   ) | sort -u
 }
 
 function bake_sorted_subtask_list () {
   for task in "${!BAKE_SUBTASKS[@]}"; do
-    echo $task
+    echo "$task"
   done | sort -u
 }
 

--- a/bake
+++ b/bake
@@ -540,18 +540,17 @@ function bake_update () {
 
 function bake_create_bakefile () {
   if [ ! -e "Bakefile" ]; then
-    cat > "Bakefile" <<END
+    cat > "Bakefile" <<'END'
 #!/usr/bin/env bash
 
 # bake_require github.com/kyleburton/bake-recipes/docker/docker.sh
 
+# Set default editor if not defined
+export EDITOR="${EDITOR:-vi}"
+
 bake_task get-started "Get started by editing this Bakefile"
 function get-started () {
-  if [ -n "$EDITOR" ]; then
     "$EDITOR" Bakefile
-  else
-    vim Bakefile
-  fi
 }
 END
   fi


### PR DESCRIPTION
When setting this up for the first time on my machine, I got an error because I didn't have an `EDITOR` environment variable set. This change fixes those errors.

```sh
$ bake init
/root/bin/bake: line 543: EDITOR: unbound variable
```

Also, when running `bake get-started` I got a similar error.

```sh
$ bake get-started
/root/Bakefile: line 7: EDITOR: unbound variable
```

I also updated the README.md because copying and pasting the commands from the examples didn't work. These updates should make it easier to copy and paste to run through the library tutorial.

Changed the default editor to `vi` since not all environments have `vim` installed.