### PR TITLE
fixes #40 - github.com urls should be valid for bake_package_install

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+2025-05-05T17:31:16Z
+  fixes #40 Github URL Parsing error (regression) introduced at commit e15295aea94cf9f750afbed66b6c011bd3f5b2bf
+  library urls that begin with `gitub.com/` should be valid for `bake_package_install`
 2019-01-11T22:02:30Z - releasing 1.0.14
   bash command line completion now only completes the first word, see: https://github.com/kyleburton/bake/pull/29
 2017-07-23T19:58:49Z - releasing 1.0.6

--- a/bake
+++ b/bake
@@ -208,10 +208,15 @@ function bake_package_install () {
   local git_host_and_user=
   local bake_library_file=
 
-  [[ $url =~ [a-zA-Z]+://([a-zA-Z0-9@-_.]+/[a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/(.*) ]] && \
-    git_host_and_user=${BASH_REMATCH[1]} && \
-    git_project_name=${BASH_REMATCH[2]} && \
-    bake_library_file=${BASH_REMATCH[3]}
+  if [[ $url =~ [a-zA-Z]+://([a-zA-Z0-9@-_.]+/[a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/(.*) ]]; then
+    git_host_and_user="${BASH_REMATCH[1]}"
+    git_project_name="${BASH_REMATCH[2]}"
+    bake_library_file="${BASH_REMATCH[3]}"
+  elif [[ $url =~ ^(github.com/[a-zA-Z0-9@-_.]+/[a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/(.*) ]]; then
+    git_host_and_user="${BASH_REMATCH[1]}"
+    git_project_name="${BASH_REMATCH[2]}"
+    bake_library_file="${BASH_REMATCH[3]}"
+  fi
 
   if [[ -z "$git_host_and_user" ]] || [[ -z "$git_project_name" ]]; then
     bake_echo_red "Error[bake_package_install] Could not parse url '$url'"


### PR DESCRIPTION
fixes #40 

```bash
> cd test
> ../bake all
...
  All tests passed
```