### PR TITLE
fixes #38 - only look for bakedir in $PWD

### DIFF
--- a/bake
+++ b/bake
@@ -383,35 +383,49 @@ function bake_cd () {
 }
 
 function bake_find_bakefile_impl () {
-  local project_root
+  local project_root look_for_bakedir
+  look_for_bakedir="yes"
+  while [[ "${1:-}" == --* ]]; do
+    case "$1" in
+      --no-bakedir)
+        look_for_bakedir=""
+        shift
+        ;;
+      *)
+        bake_echo_red "ERROR: bake_find_bakefile_impl: unsupported option '$1'"
+        return 1
+        ;;
+    esac
+  done
+
   project_root="$(pwd)"
-  if [ -f "Bakefile" ]; then
+  if [[ -f "Bakefile" ]]; then
     echo "$project_root/Bakefile"
     return 0
   fi
 
-  if [ -f "bakefile" ]; then
+  if [[ -f "bakefile" ]]; then
     echo "$project_root/bakefile"
     return 0
   fi
 
-  if [ -d "bake" ]; then
+  if [[ -n "$look_for_bakedir" && -d "bake" ]]; then
     echo "$project_root/bake"
     return 0
   fi
 
-  if [ -d "Bake" ]; then
+  if [[ -n "$look_for_bakedir" && -d "Bake" ]]; then
     echo "$project_root/Bake"
     return 0
   fi
 
-  if [ "/" = "$(pwd)" ]; then
+  if [[ "/" = "$(pwd)" ]]; then
     echo ""
     return 1;
   fi
 
   cd ..
-  bake_find_bakefile_impl
+  bake_find_bakefile_impl --no-bakedir
 }
 
 function bake_find_bakefile () {


### PR DESCRIPTION
This change has `bake` only look for `bakedirs` in the `$PWD` and not when looking for the `Bakefile` "up" the current path.

Previous behavior when run in the bake project directory:

```bash
> ./bake 
/home/kyle/code/github.com/kyleburton/bake/Changes: line 1: 2019-01-11T22:02:30Z: command not found
```

Corrected behavior:

```bash
> ./bake
Error[bake_run]: could not locate a Bakefile!

./bake task [arg ...]

Hi there!  Tasks are taken from the file Bakefile (or bakefile) in the /home/kyle/code/github.com/kyleburton/bake.
You can specify an alternate Bakefile by setting BAKEFILE:

  BAKEFILE="my.Bakefile" bake

The internal commands that bake supports are:

   init        Creates a skeleton Bakefile
   update      Updates libraries (see ~/.bake).
   upgrade     Refreshes bake itself.
   version     Show the version of bake!
```