### PR TITLE
add per-task tab completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,79 @@ $ bake mylib:foo this that
 foo: args='this that'
 ```
 
+# Tab Completion
+
+`bake` ships with a bash completion script (`bake-completion.sh`) that completes task names and, optionally, each task's arguments.
+
+## Installing completion
+
+Source the script from your shell profile:
+
+```sh
+echo 'source /path/to/bake-completion.sh' >> ~/.bashrc
+```
+
+With a homebrew install the path is typically `/usr/local/etc/bash_completion.d/bake-completion.sh`.
+
+## Static argument completion with `bake_task_complete`
+
+For tasks with a fixed set of valid arguments, pair `bake_task_complete` with your `bake_task` declaration:
+
+```sh
+bake_task deploy "Deploy the application"
+bake_task_complete deploy "production staging dev"
+function deploy () {
+  local env="$1"
+  echo "Deploying to $env"
+}
+```
+
+Pressing `<TAB>` after `bake deploy` will now offer `production`, `staging`, and `dev`.
+
+## Dynamic argument completion with `${task}:complete`
+
+For tasks that need context-aware or dynamically generated completions, define a function named `${task}:complete`. It receives the word currently being typed as `$1`, followed by any words already typed for that task's arguments.
+
+After `shift`ing off `$1`, the remaining `$#` equals the number of arguments already completed, making positional completion straightforward:
+
+```sh
+bake_task deploy "Deploy a service to an environment"
+function deploy () {
+  local env="$1" service="$2" version="$3"
+  # ... deploy logic
+}
+
+function deploy:complete () {
+  local cur="$1"
+  shift
+  # $# is now the count of already-typed arguments
+  local arg_pos=$#
+
+  case "$arg_pos" in
+    0)
+      echo "production staging dev"
+      ;;
+    1)
+      local env="$1"
+      case "$env" in
+        production) echo "api worker frontend" ;;
+        staging)    echo "api worker frontend debug-service" ;;
+        dev)        echo "api worker frontend debug-service mock-service" ;;
+        *)          echo "api worker frontend" ;;
+      esac
+      ;;
+    2)
+      # Pull versions dynamically from git tags
+      git tag --list 'v*' 2>/dev/null
+      ;;
+  esac
+}
+```
+
+The completion function just echoes candidates to stdout — no bash completion internals required. The completion script filters them against the current word automatically.
+
+If neither `${task}:complete` nor a `bake_task_complete` registration exists for a task, argument completion falls back to filename completion.
+
 ## The "API", aka what shell functions can you call from your `Bakefile`?
 
 `bake` is controlled by a `Bakefile` (similarly to make and rake).  This file is just a bash script.  You define functions for your tasks and register them with `bake`.  `bake` itself is essentially a set of shell functions and you can (and are encouraged) to use them from within your `Bakefile`s.  This is an overview of the most useful ones (feel free to look around inside `bake` and see what else is there).
@@ -85,6 +158,10 @@ foo: args='this that'
 ### `bake_task task-name "task-description"`
 
 This registers a task and its description so it can be executed and help can be displayed.
+
+### `bake_task_complete task-name "word1 word2 ..."`
+
+Registers a static list of completion candidates for a task's arguments. Used by the bash completion script when the user presses `<TAB>` after the task name. For context-aware or dynamic completions, define a `${task}:complete` function instead (see [Tab Completion](#tab-completion)).
 
 ### `bake_default_task task-name`
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ function deploy () {
 
 Pressing `<TAB>` after `bake deploy` will now offer `production`, `staging`, and `dev`.
 
+Completion candidates must be whitespace-separated words.
+
+Note that `${task}:complete` takes precedence over `bake_task_complete`.
+
 ## Dynamic argument completion with `${task}:complete`
 
 For tasks that need context-aware or dynamically generated completions, define a function named `${task}:complete`. It receives the word currently being typed as `$1`, followed by any words already typed for that task's arguments.
@@ -150,6 +154,10 @@ function deploy:complete () {
 The completion function just echoes candidates to stdout — no bash completion internals required. The completion script filters them against the current word automatically.
 
 If neither `${task}:complete` nor a `bake_task_complete` registration exists for a task, argument completion falls back to filename completion.
+
+Completion candidates must be whitespace-separated words.
+
+Note that `${task}:complete` takes precedence over `bake_task_complete`.
 
 ## The "API", aka what shell functions can you call from your `Bakefile`?
 

--- a/bake
+++ b/bake
@@ -353,7 +353,14 @@ function bake_task_complete () {
     echo "Error[bake_task_complete]: you must supply a task name!"
     return 1
   fi
-  BAKE_TASK_COMPLETIONS[$name]="$completions"
+
+  if bake_is_registered_task "$name"; then
+    BAKE_TASK_COMPLETIONS[$name]="$completions"
+    return 0
+  fi
+
+  echo "Error[bake_task_complete]: not a registered task:'$task'"
+  return 1
 }
 
 function bake_complete_task () {

--- a/bake
+++ b/bake
@@ -359,7 +359,8 @@ function bake_task_complete () {
 function bake_complete_task () {
   local task="$1"
   local cur="${2:-}"
-  shift 2 || true
+  local n_shift=$(( $# < 2 ? $# : 2 ))
+  shift "$n_shift"
 
   if declare -f "${task}:complete" > /dev/null 2>&1; then
     "${task}:complete" "$cur" "$@"

--- a/bake
+++ b/bake
@@ -45,6 +45,7 @@ declare -A BAKE_SUPERTASKS
 declare -A BAKE_SUBTASKS
 declare -A BAKE_TASK_DESCRIPTIONS
 declare -A BAKE_SUPERTASK_DESCRIPTIONS
+declare -A BAKE_TASK_COMPLETIONS
 declare -A BAKE_LIBS
 
 function bake_push_libdir () {
@@ -212,10 +213,11 @@ function bake_package_install () {
     git_host_and_user="${BASH_REMATCH[1]}"
     git_project_name="${BASH_REMATCH[2]}"
     bake_library_file="${BASH_REMATCH[3]}"
-  elif [[ $url =~ ^(github.com/[a-zA-Z0-9@-_.]+/[a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/(.*) ]]; then
+  elif [[ $url =~ ^(github.com/[a-zA-Z0-9@-_.]+)/([a-zA-Z0-9_-]+)/(.*) ]]; then
     git_host_and_user="${BASH_REMATCH[1]}"
     git_project_name="${BASH_REMATCH[2]}"
     bake_library_file="${BASH_REMATCH[3]}"
+    schema="https"
   fi
 
   if [[ -z "$git_host_and_user" ]] || [[ -z "$git_project_name" ]]; then
@@ -344,6 +346,32 @@ function bake_supertask () {
   BAKE_SUPERTASK_DESCRIPTIONS[$supertask_name]="$short_desc"
 }
 
+function bake_task_complete () {
+  local name="${1:-}"
+  local completions="${2:-}"
+  if [ -z "$name" ]; then
+    echo "Error[bake_task_complete]: you must supply a task name!"
+    return 1
+  fi
+  BAKE_TASK_COMPLETIONS[$name]="$completions"
+}
+
+function bake_complete_task () {
+  local task="$1"
+  local cur="${2:-}"
+  shift 2 || true
+
+  if declare -f "${task}:complete" > /dev/null 2>&1; then
+    "${task}:complete" "$cur" "$@"
+    return
+  fi
+
+  if [[ -n "${BAKE_TASK_COMPLETIONS[$task]:-}" ]]; then
+    echo "${BAKE_TASK_COMPLETIONS[$task]}"
+    return
+  fi
+}
+
 function bake_task_short_desc () {
   local name="${1:-}"
   local descr
@@ -432,7 +460,13 @@ function bake_find_bakefile () {
   local start_path
   start_path="$(pwd)"
   if [ -n "${BAKEFILE:-}" ]; then
-    echo "$BAKEFILE"
+    # Resolve to an absolute path so bake_cd works correctly regardless of
+    # where the caller set BAKEFILE relative to.
+    if [[ "$BAKEFILE" != /* ]]; then
+      echo "$start_path/$BAKEFILE"
+    else
+      echo "$BAKEFILE"
+    fi
     return 0
   fi
 
@@ -619,6 +653,11 @@ function bake_run () {
 
   export BAKEFILE="$bakefile"
   bake_source_bakefile "$bakefile"
+
+  if [ "$task" == "--complete" ]; then
+    bake_complete_task "$@"
+    return 0
+  fi
 
   if [ -n "$task" ]; then
     if bake_is_registered_task "$task"; then

--- a/bake-completion.sh
+++ b/bake-completion.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 
 _bake () {
-  local cword cur tasks
-  _get_comp_words_by_ref -n : -c cur cword
+  local cword cur words
+  _get_comp_words_by_ref -n : -c cur -w words cword
   tasks="$(bake | grep -v BAKEFILE | grep '^  ' | sed 's/^  //g' | cut -f1 -d' ')"
   if [[ "$cword" -eq "1" ]]; then
     mapfile -t COMPREPLY < <(compgen -W "$tasks" -- "$cur")
   else
-    mapfile -t COMPREPLY < <(compgen -o default -- "$cur")
+    local task="${words[1]}"
+    local prior=("${words[@]:2:$((cword - 2))}")
+    local candidates
+    candidates="$(bake --complete "$task" "$cur" "${prior[@]}" 2>/dev/null)"
+    if [[ -n "$candidates" ]]; then
+      mapfile -t COMPREPLY < <(compgen -W "$candidates" -- "$cur")
+    else
+      mapfile -t COMPREPLY < <(compgen -o default -- "$cur")
+    fi
   fi
 
   # NB: this is a workaround for bash's default of splitting words on colons

--- a/test/Bakefile
+++ b/test/Bakefile
@@ -223,6 +223,112 @@ function 13_local_require_support () {
   test_passed
 }
 
+bake_test 14_task_complete_static
+function 14_task_complete_static () {
+  in_test "${FUNCNAME[0]}"
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  cat > "$tmpdir/Bakefile" <<'EOF'
+bake_task deploy "Deploy the application"
+bake_task_complete deploy "production staging dev"
+function deploy () { echo "deploying $*"; }
+EOF
+  local result
+  result="$(BAKEFILE="$tmpdir/Bakefile" ../bake --complete deploy "")"
+  rm -rf "$tmpdir"
+  if [[ "$result" == "production staging dev" ]]; then
+    test_passed
+  else
+    bake_echo_red "Expected 'production staging dev', got '$result'"
+    return 1
+  fi
+}
+
+bake_test 15_task_complete_function
+function 15_task_complete_function () {
+  in_test "${FUNCNAME[0]}"
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  cat > "$tmpdir/Bakefile" <<'EOF'
+bake_task ship "Ship a service"
+function ship () { echo "shipping $*"; }
+function ship:complete () {
+  local cur="$1"
+  shift
+  echo "production staging dev"
+}
+EOF
+  local result
+  result="$(BAKEFILE="$tmpdir/Bakefile" ../bake --complete ship "")"
+  rm -rf "$tmpdir"
+  if [[ "$result" == "production staging dev" ]]; then
+    test_passed
+  else
+    bake_echo_red "Expected 'production staging dev', got '$result'"
+    return 1
+  fi
+}
+
+bake_test 16_task_complete_positional
+function 16_task_complete_positional () {
+  in_test "${FUNCNAME[0]}"
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  cat > "$tmpdir/Bakefile" <<'EOF'
+bake_task deploy "Deploy a service to an environment"
+function deploy () { echo "deploying $*"; }
+function deploy:complete () {
+  local cur="$1"
+  shift
+  local arg_pos=$#
+  case "$arg_pos" in
+    0) echo "production staging dev" ;;
+    1) echo "api worker frontend" ;;
+    2) echo "v1.0 v1.1 v2.0" ;;
+  esac
+}
+EOF
+  local r0 r1 r2
+  r0="$(BAKEFILE="$tmpdir/Bakefile" ../bake --complete deploy "")"
+  r1="$(BAKEFILE="$tmpdir/Bakefile" ../bake --complete deploy "" staging)"
+  r2="$(BAKEFILE="$tmpdir/Bakefile" ../bake --complete deploy "" staging api)"
+  rm -rf "$tmpdir"
+
+  if [[ "$r0" != "production staging dev" ]]; then
+    bake_echo_red "pos=0: expected 'production staging dev', got '$r0'"
+    return 1
+  fi
+  if [[ "$r1" != "api worker frontend" ]]; then
+    bake_echo_red "pos=1: expected 'api worker frontend', got '$r1'"
+    return 1
+  fi
+  if [[ "$r2" != "v1.0 v1.1 v2.0" ]]; then
+    bake_echo_red "pos=2: expected 'v1.0 v1.1 v2.0', got '$r2'"
+    return 1
+  fi
+  test_passed
+}
+
+bake_test 17_task_complete_no_output_when_unregistered
+function 17_task_complete_no_output_when_unregistered () {
+  in_test "${FUNCNAME[0]}"
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  cat > "$tmpdir/Bakefile" <<'EOF'
+bake_task build "Build the project"
+function build () { echo "building"; }
+EOF
+  local result
+  result="$(BAKEFILE="$tmpdir/Bakefile" ../bake --complete build "" 2>&1)"
+  rm -rf "$tmpdir"
+  if [[ -z "$result" ]]; then
+    test_passed
+  else
+    bake_echo_red "Expected empty output for unregistered completion, got '$result'"
+    return 1
+  fi
+}
+
 bake_task all
 function all () {
   bake_log_level fatal


### PR DESCRIPTION
Introduces `bake_task_complete` for registering static argument completions and `${task}:complete` functions for dynamic/positional completions. The `bake --complete` dispatch is called from the bash completion script, which passes prior arguments to enable context-aware suggestions.

See the `README.md` for documentation and usage.

Implements #37 